### PR TITLE
Container refresh and fixes

### DIFF
--- a/haproxy/Dockerfile.template
+++ b/haproxy/Dockerfile.template
@@ -1,7 +1,7 @@
 # haproxy http/https proxy
 ARG OP_MACHINE_NAME
 
-FROM resin/${OP_MACHINE_NAME:-%%RESIN_MACHINE_NAME%%}-debian:stretch
+FROM balenalib/${OP_MACHINE_NAME:-%%RESIN_MACHINE_NAME%%}-debian:buster
 
 RUN apt-get update && \
     apt-get install haproxy ssl-cert && \

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -35,6 +35,7 @@ RUN if [ "${release}" = "latest" ]; then \
     echo "Building Octoprint ${release}"; \
     git clone --branch "${release}" https://github.com/foosel/OctoPrint.git /opt/octoprint/OctoPrint && \
     python -m virtualenv venv && \
+      ./venv/bin/pip install MarkupSafe && \
       ./venv/bin/python setup.py install
 
 WORKDIR /opt/octoprint

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -10,7 +10,7 @@ SHELL ["/bin/bash", "-c"]
 RUN [[ -f /bin/sh.real ]] && rm /bin/sh && mv /bin/sh.real /bin/sh
 
 RUN apt-get update && \
-    apt-get install python-pip python-dev python-setuptools virtualenv \
+    apt-get install python-pip python-dev python-setuptools \
             python-virtualenv git libyaml-dev build-essential ffmpeg dbus \
             jq zlib1g-dev libjpeg62-turbo-dev && \
     apt-get clean && \
@@ -34,8 +34,8 @@ RUN if [ "${release}" = "latest" ]; then \
     fi; \
     echo "Building Octoprint ${release}"; \
     git clone --branch "${release}" https://github.com/foosel/OctoPrint.git /opt/octoprint/OctoPrint && \
-    virtualenv venv && \
-      ./venv/bin/python setup.py install 
+    python -m virtualenv venv && \
+      ./venv/bin/python setup.py install
 
 WORKDIR /opt/octoprint
 

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -1,9 +1,13 @@
 # Octoprint itself
 ARG OP_MACHINE_NAME
 
-FROM resin/${OP_MACHINE_NAME:-%%RESIN_MACHINE_NAME%%}-debian:stretch
+FROM balenalib/${OP_MACHINE_NAME:-%%RESIN_MACHINE_NAME%%}-debian:buster
 
 SHELL ["/bin/bash", "-c"]
+
+# Balena /bin/sh stub is supposed to cleanup itself, but loops when initally called by apt...
+# https://github.com/balena-io-library/base-images/issues/637
+RUN [[ -f /bin/sh.real ]] && rm /bin/sh && mv /bin/sh.real /bin/sh
 
 RUN apt-get update && \
     apt-get install python-pip python-dev python-setuptools virtualenv \

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -16,18 +16,19 @@ WORKDIR /opt/octoprint/OctoPrint
 
 ARG release
 
-# Travis often fails in getting latest octoprint release, this is why we 
+# Travis often fails in getting latest octoprint release, this is why we
 # have this while/re-try loop...
 RUN if [ "${release}" = "latest" ]; then \
       i=0; \
       while true; do \
         i=$(expr $i + 1); \
-        release=$(curl --silent https://api.github.com/repos/foosel/OctoPrint/releases/latest | jq -r .tag_name); \
+        release=$(curl --silent --location https://api.github.com/repos/foosel/OctoPrint/releases/latest | jq -r .tag_name); \
         [ "${release}" = "null" -a $i -lt 10 ] || break;\
         echo "Cannot get release info -- retrying"; \
         sleep 10; \
       done; \
     fi; \
+    echo "Building Octoprint ${release}"; \
     git clone --branch "${release}" https://github.com/foosel/OctoPrint.git /opt/octoprint/OctoPrint && \
     virtualenv venv && \
       ./venv/bin/python setup.py install 

--- a/webcam/Dockerfile.template
+++ b/webcam/Dockerfile.template
@@ -1,7 +1,7 @@
 # Webcam streamer
 ARG OP_MACHINE_NAME
 
-FROM resin/${OP_MACHINE_NAME:-%%RESIN_MACHINE_NAME%%}-debian:stretch
+FROM balenalib/${OP_MACHINE_NAME:-%%RESIN_MACHINE_NAME%%}-debian:buster
 
 RUN apt-get update && \
     apt-get install python-flask git build-essential subversion \


### PR DESCRIPTION
Several enhancements:
- Use latest Balena containers
- Don't pull python3 anymore
- Fix pull of _latest_ octoprint tag (Issue #5)
- Workaround for Jija2/MarkDown dependency issue (issue #5 / https://github.com/OctoPrint/OctoPrint/commit/4ddaf350b4dd03c0bfa2bb6bc39ef49ac99e6d34)